### PR TITLE
Drain Star Coins with Timer

### DIFF
--- a/main.tscn
+++ b/main.tscn
@@ -15,6 +15,10 @@ position = Vector2( 500, 300 )
 position = Vector2( 500, 200 )
 
 [node name="HUD" parent="." instance=ExtResource( 2 )]
+
+[node name="Tax_Timer" type="Timer" parent="."]
+autostart = true
 [connection signal="set_star_coin_increase" from="Player" to="." method="_on_Player_set_star_coin_increase"]
 [connection signal="body_entered" from="Market_Area_Welcome" to="Player" method="_on_Market_Area_Welcome_body_entered"]
 [connection signal="body_exited" from="Market_Area_Welcome" to="Player" method="_on_Market_Area_Welcome_body_exited"]
+[connection signal="timeout" from="Tax_Timer" to="Player" method="_on_Tax_Timer_timeout"]


### PR DESCRIPTION
Add a lose condition to the game when the player runs out of Star Coins over time.

- After the player's first move, begin losing a Star Coin every second.
- If Star Coins reach zero, lock player movement to end the game.

Technically this logic should probably moved into a separate file to call `start()` and `stop()` on the timer directly. That can be logged as an enhancement bug for later.