### PR TITLE
Update Game Conditions for Loss, Smile, and Full Healthiness

### DIFF
--- a/game_over_conditions.gd
+++ b/game_over_conditions.gd
@@ -2,7 +2,6 @@ extends Node
 
 
 const GAME_OVER_LOSE_HEALTH_AMOUNT = 0
-const GAME_OVER_LOSE_STAR_COIN_AMOUNT = 0
 const GAME_OVER_LOSE_TEXT = "Game Over"
 const GAME_OVER_WIN_STAR_COIN_AMOUNT = 10
 const GAME_OVER_WIN_TEXT = "Congratulations!"
@@ -14,7 +13,7 @@ onready var player_variables = get_node("/root/PlayerVariables")
 func get_game_over_text():
 	if is_player_rich():
 		return GAME_OVER_WIN_TEXT
-	elif is_player_out_of_money() || is_player_out_of_health():
+	elif is_player_out_of_health():
 		return GAME_OVER_LOSE_TEXT
 	else:
 		return ""
@@ -23,12 +22,6 @@ func is_player_rich():
 	return (
 		player_variables.player_currency_star_coin
 		>= GAME_OVER_WIN_STAR_COIN_AMOUNT
-	)
-
-func is_player_out_of_money():
-	return (
-		player_variables.player_currency_star_coin
-		<= GAME_OVER_LOSE_STAR_COIN_AMOUNT
 	)
 
 func is_player_out_of_health():

--- a/player/player.gd
+++ b/player/player.gd
@@ -18,7 +18,7 @@ const INCOME_FROM_MARKET_AREA_SAW_HEALTH = -1
 const INCOME_FROM_MARKET_AREA_SAW_SMILE = -1
 const INCOME_FROM_MARKET_AREA_SAW_STAR_COINS = 2
 const MAX_SPEED = 400
-const TAX_STAR_COINS = -1
+const TAX_HEALTH = -1
 
 var is_player_asleep = true
 var motion = Vector2()
@@ -300,16 +300,16 @@ func _deactivate_Market_Area_Welcome(body):
 			+ " after leaving " + str(body))
 
 
-# Logic for passive loss of star coin currency
+# Logic for passive loss of health while smile is empty and game is not over
 func _start_Tax_Timer():
 	if is_player_asleep && !game_over_conditions.is_player_rich():
 		is_player_asleep = false
 
 func _on_Tax_Timer_timeout():
-	if !is_player_asleep:
+	if !is_player_asleep && player_variables.player_current_smile <= 0:
 		emit_signal(
-			"set_star_coin_increase",
-			TAX_STAR_COINS
+			"set_health_increase",
+			TAX_HEALTH
 		)
 
 func _stop_Tax_Timer():

--- a/player/player.gd
+++ b/player/player.gd
@@ -50,10 +50,7 @@ onready var player_variables = get_node("/root/PlayerVariables")
 # Player Movement methods
 func _physics_process(delta):
 	# Stop timer and moving if player is out of money or health
-	if (
-		game_over_conditions.is_player_out_of_money()
-		|| game_over_conditions.is_player_out_of_health()
-	):
+	if game_over_conditions.is_player_out_of_health():
 		is_player_asleep = true
 		return
 

--- a/player/player.gd
+++ b/player/player.gd
@@ -154,12 +154,21 @@ func _on_Market_Area_Saw_body_entered(body):
 
 # Market Area Valentine collision method
 func _on_Market_Area_Valentine_body_entered(body):
-	var minimum_envelopes = 0
 	var remaining_envelopes = (
 		player_variables.player_currency_envelope
 		+ INCOME_FROM_MARKET_AREA_VALENTINE_ENVELOPES
 	)
-	if remaining_envelopes >= minimum_envelopes:
+	var can_afford = remaining_envelopes >= 0
+	var can_benefit = (
+		(
+			player_variables.player_current_health
+			< player_variables.INITIAL_MAX_HEALTH
+		) || (
+			player_variables.player_current_smile
+			< player_variables.INITIAL_MAX_SMILE
+		)
+	)
+	if can_afford && can_benefit:
 		_activate_Market_Area_Valentine(body)
 	else:
 		emit_signal("cannot_affort_market_area_valentine", body)

--- a/player/player.gd
+++ b/player/player.gd
@@ -92,12 +92,17 @@ func _get_input_axis():
 
 # Market Area Bed collision method
 func _on_Market_Area_Bed_body_entered(body):
-	var minimum_star_coins = 0
 	var remaining_star_coins = (
 		player_variables.player_currency_star_coin
 		+ INCOME_FROM_MARKET_AREA_BED_STAR_COINS
 	)
-	if remaining_star_coins >= minimum_star_coins:
+	var can_afford = remaining_star_coins >= 0
+	var can_benefit = (
+		player_variables.player_current_health
+		< player_variables.INITIAL_MAX_HEALTH
+	)
+
+	if can_afford && can_benefit:
 		_activate_Market_Area_Bed(body)
 	else:
 		emit_signal("cannot_affort_market_area_bed", body)


### PR DESCRIPTION
Change the game rules:

 * The player may only lose by running out of Health.
 * Instead of always draining Star Coins every second, drain Health only while Smile is empty.
 * Prevent the player from using healing areas if they will not benefit.
   * Bed when full Health
   * Valentine when full Health and Smile

**Existing behavior:** Note that if the player runs out of health, they cannot move, even if they won.