### PR TITLE
Increase Win Condition from 10 to 100 Star Coins

### DIFF
--- a/game_over_conditions.gd
+++ b/game_over_conditions.gd
@@ -3,7 +3,7 @@ extends Node
 
 const GAME_OVER_LOSE_HEALTH_AMOUNT = 0
 const GAME_OVER_LOSE_TEXT = "Game Over"
-const GAME_OVER_WIN_STAR_COIN_AMOUNT = 10
+const GAME_OVER_WIN_STAR_COIN_AMOUNT = 100
 const GAME_OVER_WIN_TEXT = "Congratulations!"
 
 

--- a/hud/star_coins_number.gd
+++ b/hud/star_coins_number.gd
@@ -1,8 +1,21 @@
 extends Label
 
 
+onready var game_over_conditions = get_node("/root/GameOverConditions")
 onready var player_variables = get_node("/root/PlayerVariables")
 
 
 func _process(_delta):
-	text = str(player_variables.player_currency_star_coin)
+	text = _get_star_coin_amount_and_goal()
+
+func _get_star_coin_amount_and_goal():
+	var amount = str(player_variables.player_currency_star_coin)
+	var goal = ""
+
+	if game_over_conditions.GAME_OVER_WIN_STAR_COIN_AMOUNT > 0:
+		goal = (
+			" / "
+			+ str(game_over_conditions.GAME_OVER_WIN_STAR_COIN_AMOUNT)
+		)
+
+	return amount + goal


### PR DESCRIPTION
Increase win condition to fit the updated balance, and show the amount needed to win on the HUD's Star Coin counter.