### PR TITLE
Bug Fix - Fix Asset Path for Heart on HUD

### DIFF
--- a/hud/hud.tscn
+++ b/hud/hud.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=17 format=2]
 
-[ext_resource path="res://hud/heart.png" type="Texture" id=1]
+[ext_resource path="res://assets/heart.png" type="Texture" id=1]
 [ext_resource path="res://hud/health-bar-empty.png" type="Texture" id=2]
 [ext_resource path="res://hud/health-bar-filling.png" type="Texture" id=3]
 [ext_resource path="res://assets/star-coin.png" type="Texture" id=4]


### PR DESCRIPTION
The top-left heart in the HUD will now show up.