### PR TITLE
Engine Update - Upgrade to Latest Godot 4.6 AND Slightly Enlarge Market Area Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Team members include:
 Coded using the [Godot](https://godotengine.org) game engine.
 
 The original game jam version, tagged as `ld47-submission` and [hosted on itch.io](https://nbumgardner.itch.io/ludum-dare-47-enough), runs on Godot version 3.2.
-The latest stable `master` code branch runs on Godot version 4.5.
+The latest stable `master` code branch runs on Godot version 4.6.
 
 ### License
 This game's code is open-source under the MIT License.

--- a/assets/themes/font_size_market_area_numbers_theme.tres
+++ b/assets/themes/font_size_market_area_numbers_theme.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Theme" format=3 uid="uid://cn2i804sa0rst"]
+
+[resource]
+Label/font_sizes/font_size = 24

--- a/default_env.tres
+++ b/default_env.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Environment" load_steps=2 format=3 uid="uid://4sq3cscyivt0"]
+[gd_resource type="Environment" format=3 uid="uid://4sq3cscyivt0"]
 
 [sub_resource type="Sky" id="1"]
 

--- a/hud/hud.tscn
+++ b/hud/hud.tscn
@@ -1,147 +1,150 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene format=3 uid="uid://ciapiphyir28b"]
 
-[ext_resource path="res://assets/heart.png" type="Texture2D" id=1]
-[ext_resource path="res://hud/health-bar-empty.png" type="Texture2D" id=2]
-[ext_resource path="res://hud/health-bar-filling.png" type="Texture2D" id=3]
-[ext_resource path="res://assets/star-coin.png" type="Texture2D" id=4]
-[ext_resource path="res://hud/star_coins_number.gd" type="Script" id=5]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=6]
-[ext_resource path="res://hud/game_over_text.gd" type="Script" id=7]
-[ext_resource path="res://assets/envelope.png" type="Texture2D" id=8]
-[ext_resource path="res://hud/envelopes_number.gd" type="Script" id=9]
-[ext_resource path="res://hud/pizza_slices_number.gd" type="Script" id=10]
-[ext_resource path="res://assets/pizza-slice.png" type="Texture2D" id=11]
-[ext_resource path="res://hud/health_bar.gd" type="Script" id=12]
-[ext_resource path="res://assets/smile.png" type="Texture2D" id=13]
-[ext_resource path="res://hud/smile_bar.gd" type="Script" id=14]
+[ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="1"]
+[ext_resource type="Texture2D" uid="uid://cxgq1tj5vt7rp" path="res://hud/health-bar-empty.png" id="2"]
+[ext_resource type="Texture2D" uid="uid://8lw0qyyf58ph" path="res://hud/health-bar-filling.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="4"]
+[ext_resource type="Script" uid="uid://dv4hxvgaafo8g" path="res://hud/star_coins_number.gd" id="5"]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="6"]
+[ext_resource type="Script" uid="uid://b0n5st5854l01" path="res://hud/game_over_text.gd" id="7"]
+[ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="8"]
+[ext_resource type="Script" uid="uid://d04mo273r43v7" path="res://hud/envelopes_number.gd" id="9"]
+[ext_resource type="Script" uid="uid://cveoexdkbhsyr" path="res://hud/pizza_slices_number.gd" id="10"]
+[ext_resource type="Texture2D" uid="uid://cwb3e2bcbiu1w" path="res://assets/pizza-slice.png" id="11"]
+[ext_resource type="Script" uid="uid://ct6nblcbsx85k" path="res://hud/health_bar.gd" id="12"]
+[ext_resource type="Texture2D" uid="uid://dw6q5e5eo0dvi" path="res://assets/smile.png" id="13"]
+[ext_resource type="Script" uid="uid://cuhvx5qgrbjmk" path="res://hud/smile_bar.gd" id="14"]
 
-[sub_resource type="FontFile" id=1]
-size = 32
-font_data = ExtResource( 6 )
+[sub_resource type="FontFile" id="1"]
+fallbacks = Array[Font]([ExtResource("6"), ExtResource("6")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="FontFile" id=2]
-font_data = ExtResource( 6 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("6"), ExtResource("6")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[node name="GUI" type="MarginContainer"]
+[node name="GUI" type="MarginContainer" unique_id=440292271]
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 20.0
 offset_top = 20.0
 offset_right = -20.0
 offset_bottom = -20.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Game Over Text" type="Label" parent="."]
-offset_right = 984.0
-offset_bottom = 38.0
+[node name="Game Over Text" type="Label" parent="." unique_id=1630799118]
+layout_mode = 2
 size_flags_vertical = 0
-theme_override_fonts/font = SubResource( 1 )
-align = 1
-script = ExtResource( 7 )
+theme_override_fonts/font = SubResource("1")
+horizontal_alignment = 1
+script = ExtResource("7")
 
-[node name="resources_container" type="HBoxContainer" parent="."]
-offset_right = 984.0
-offset_bottom = 560.0
+[node name="resources_container" type="HBoxContainer" parent="." unique_id=842759240]
+layout_mode = 2
 
-[node name="Bars" type="VBoxContainer" parent="resources_container"]
-offset_right = 944.0
-offset_bottom = 560.0
+[node name="Bars" type="VBoxContainer" parent="resources_container" unique_id=2027571322]
+layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="Health Bar" type="HBoxContainer" parent="resources_container/Bars"]
-offset_right = 944.0
-offset_bottom = 32.0
+[node name="Health Bar" type="HBoxContainer" parent="resources_container/Bars" unique_id=858724619]
+layout_mode = 2
 
-[node name="Icon" type="TextureRect" parent="resources_container/Bars/Health Bar"]
-offset_right = 32.0
-offset_bottom = 32.0
-texture = ExtResource( 1 )
+[node name="Icon" type="TextureRect" parent="resources_container/Bars/Health Bar" unique_id=2131706449]
+layout_mode = 2
+texture = ExtResource("1")
 
-[node name="TextureProgressBar" type="TextureProgressBar" parent="resources_container/Bars/Health Bar"]
-offset_left = 36.0
-offset_right = 292.0
-offset_bottom = 32.0
-texture_under = ExtResource( 2 )
-texture_progress = ExtResource( 3 )
-script = ExtResource( 12 )
+[node name="TextureProgressBar" type="TextureProgressBar" parent="resources_container/Bars/Health Bar" unique_id=515376330]
+layout_mode = 2
+texture_under = ExtResource("2")
+texture_progress = ExtResource("3")
+script = ExtResource("12")
 
-[node name="Smile Bar" type="HBoxContainer" parent="resources_container/Bars"]
-offset_top = 36.0
-offset_right = 944.0
-offset_bottom = 68.0
+[node name="Smile Bar" type="HBoxContainer" parent="resources_container/Bars" unique_id=1492599008]
+layout_mode = 2
 
-[node name="Icon" type="TextureRect" parent="resources_container/Bars/Smile Bar"]
-offset_right = 32.0
-offset_bottom = 32.0
-texture = ExtResource( 13 )
+[node name="Icon" type="TextureRect" parent="resources_container/Bars/Smile Bar" unique_id=2015240746]
+layout_mode = 2
+texture = ExtResource("13")
 
-[node name="TextureProgressBar" type="TextureProgressBar" parent="resources_container/Bars/Smile Bar"]
-offset_left = 36.0
-offset_right = 292.0
-offset_bottom = 32.0
-texture_under = ExtResource( 2 )
-texture_progress = ExtResource( 3 )
-script = ExtResource( 14 )
+[node name="TextureProgressBar" type="TextureProgressBar" parent="resources_container/Bars/Smile Bar" unique_id=750373399]
+layout_mode = 2
+texture_under = ExtResource("2")
+texture_progress = ExtResource("3")
+script = ExtResource("14")
 
-[node name="Counters" type="VBoxContainer" parent="resources_container"]
-offset_left = 948.0
-offset_right = 984.0
-offset_bottom = 560.0
+[node name="Counters" type="VBoxContainer" parent="resources_container" unique_id=368428560]
+layout_mode = 2
 
-[node name="Star Coins" type="HBoxContainer" parent="resources_container/Counters"]
-offset_right = 36.0
-offset_bottom = 32.0
+[node name="Star Coins" type="HBoxContainer" parent="resources_container/Counters" unique_id=242741756]
+layout_mode = 2
 
-[node name="Number" type="Label" parent="resources_container/Counters/Star Coins"]
-offset_top = 6.0
-offset_bottom = 25.0
+[node name="Number" type="Label" parent="resources_container/Counters/Star Coins" unique_id=400835142]
+layout_mode = 2
 size_flags_horizontal = 3
-theme_override_fonts/font = SubResource( 2 )
-align = 2
-script = ExtResource( 5 )
+theme_override_fonts/font = SubResource("2")
+horizontal_alignment = 2
+script = ExtResource("5")
 
-[node name="Icon" type="TextureRect" parent="resources_container/Counters/Star Coins"]
-offset_left = 4.0
-offset_right = 36.0
-offset_bottom = 32.0
-texture = ExtResource( 4 )
+[node name="Icon" type="TextureRect" parent="resources_container/Counters/Star Coins" unique_id=389818621]
+layout_mode = 2
+texture = ExtResource("4")
 
-[node name="Envelopes" type="HBoxContainer" parent="resources_container/Counters"]
-offset_top = 36.0
-offset_right = 36.0
-offset_bottom = 68.0
+[node name="Envelopes" type="HBoxContainer" parent="resources_container/Counters" unique_id=614012280]
+layout_mode = 2
 
-[node name="Number" type="Label" parent="resources_container/Counters/Envelopes"]
-offset_top = 6.0
-offset_bottom = 25.0
+[node name="Number" type="Label" parent="resources_container/Counters/Envelopes" unique_id=1129697603]
+layout_mode = 2
 size_flags_horizontal = 3
-theme_override_fonts/font = SubResource( 2 )
-align = 2
-script = ExtResource( 9 )
+theme_override_fonts/font = SubResource("2")
+horizontal_alignment = 2
+script = ExtResource("9")
 
-[node name="Icon" type="TextureRect" parent="resources_container/Counters/Envelopes"]
-offset_left = 4.0
-offset_right = 36.0
-offset_bottom = 32.0
-texture = ExtResource( 8 )
+[node name="Icon" type="TextureRect" parent="resources_container/Counters/Envelopes" unique_id=1582304057]
+layout_mode = 2
+texture = ExtResource("8")
 
-[node name="Pizza Slices" type="HBoxContainer" parent="resources_container/Counters"]
-offset_top = 72.0
-offset_right = 36.0
-offset_bottom = 104.0
+[node name="Pizza Slices" type="HBoxContainer" parent="resources_container/Counters" unique_id=1149181879]
+layout_mode = 2
 
-[node name="Number" type="Label" parent="resources_container/Counters/Pizza Slices"]
-offset_top = 6.0
-offset_bottom = 25.0
+[node name="Number" type="Label" parent="resources_container/Counters/Pizza Slices" unique_id=1504725467]
+layout_mode = 2
 size_flags_horizontal = 3
-theme_override_fonts/font = SubResource( 2 )
-align = 2
-script = ExtResource( 10 )
+theme_override_fonts/font = SubResource("2")
+horizontal_alignment = 2
+script = ExtResource("10")
 
-[node name="Icon" type="TextureRect" parent="resources_container/Counters/Pizza Slices"]
-offset_left = 4.0
-offset_right = 36.0
-offset_bottom = 32.0
-texture = ExtResource( 11 )
+[node name="Icon" type="TextureRect" parent="resources_container/Counters/Pizza Slices" unique_id=33237731]
+layout_mode = 2
+texture = ExtResource("11")

--- a/main.tscn
+++ b/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://dc34klg246m0u"]
+[gd_scene format=3 uid="uid://dc34klg246m0u"]
 
 [ext_resource type="Script" uid="uid://1il1taxloybd" path="res://main.gd" id="1"]
 [ext_resource type="PackedScene" path="res://hud/hud.tscn" id="2"]
@@ -13,49 +13,49 @@
 [ext_resource type="PackedScene" path="res://market_area/house/market_area_house.tscn" id="11"]
 [ext_resource type="PackedScene" path="res://market_area/pizza_box/market_area_pizza_box.tscn" id="12"]
 
-[node name="Main" type="Node"]
+[node name="Main" type="Node" unique_id=508665826]
 script = ExtResource("1")
 
-[node name="Market_Area_Bed" parent="." instance=ExtResource("7")]
+[node name="Market_Area_Bed" parent="." unique_id=344510359 instance=ExtResource("7")]
 position = Vector2(300, 100)
 
-[node name="Market_Area_House" parent="." instance=ExtResource("11")]
+[node name="Market_Area_House" parent="." unique_id=1945128132 instance=ExtResource("11")]
 position = Vector2(595, 380)
 
-[node name="Market_Area_Mailbox" parent="." instance=ExtResource("9")]
+[node name="Market_Area_Mailbox" parent="." unique_id=1546359541 instance=ExtResource("9")]
 position = Vector2(595, 100)
 
-[node name="Market_Area_Pizza_Box" parent="." instance=ExtResource("12")]
+[node name="Market_Area_Pizza_Box" parent="." unique_id=755253702 instance=ExtResource("12")]
 position = Vector2(300, 380)
 
-[node name="Market_Area_Saw" parent="." instance=ExtResource("6")]
+[node name="Market_Area_Saw" parent="." unique_id=404329212 instance=ExtResource("6")]
 position = Vector2(60, 240)
 
-[node name="Market_Area_Valentine" parent="." instance=ExtResource("10")]
+[node name="Market_Area_Valentine" parent="." unique_id=849388945 instance=ExtResource("10")]
 position = Vector2(835, 240)
 
-[node name="Player" parent="." instance=ExtResource("3")]
+[node name="Player" parent="." unique_id=2143585938 instance=ExtResource("3")]
 position = Vector2(510, 305)
 
-[node name="HUD" parent="." instance=ExtResource("2")]
+[node name="HUD" parent="." unique_id=1499984137 instance=ExtResource("2")]
 anchors_preset = 15
 
-[node name="Tax_Timer" type="Timer" parent="."]
+[node name="Tax_Timer" type="Timer" parent="." unique_id=1465391825]
 autostart = true
 
-[node name="Music_Autumn" type="AudioStreamPlayer" parent="."]
+[node name="Music_Autumn" type="AudioStreamPlayer" parent="." unique_id=1169515273]
 stream = ExtResource("4")
 autoplay = true
 
-[node name="SFX_Add_2_Star_Coins" type="AudioStreamPlayer" parent="."]
+[node name="SFX_Add_2_Star_Coins" type="AudioStreamPlayer" parent="." unique_id=99002273]
 stream = ExtResource("5")
 
-[node name="SFX_Cannot_Afford" type="AudioStreamPlayer" parent="."]
+[node name="SFX_Cannot_Afford" type="AudioStreamPlayer" parent="." unique_id=424165225]
 stream = ExtResource("8")
 
-[node name="ParallaxBackground" type="ParallaxBackground" parent="."]
+[node name="ParallaxBackground" type="ParallaxBackground" parent="." unique_id=475683371]
 
-[node name="ColorRect" type="ColorRect" parent="ParallaxBackground"]
+[node name="ColorRect" type="ColorRect" parent="ParallaxBackground" unique_id=1298770203]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0

--- a/main.tscn
+++ b/main.tscn
@@ -1,17 +1,17 @@
 [gd_scene format=3 uid="uid://dc34klg246m0u"]
 
 [ext_resource type="Script" uid="uid://1il1taxloybd" path="res://main.gd" id="1"]
-[ext_resource type="PackedScene" path="res://hud/hud.tscn" id="2"]
-[ext_resource type="PackedScene" path="res://player/player.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://ciapiphyir28b" path="res://hud/hud.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://dbagp57b81o6t" path="res://player/player.tscn" id="3"]
 [ext_resource type="AudioStream" uid="uid://b2gwcp7vc4o4a" path="res://assets/music-autumn.ogg" id="4"]
 [ext_resource type="AudioStream" uid="uid://dd3jtauamiiu3" path="res://assets/double-coin.wav" id="5"]
-[ext_resource type="PackedScene" path="res://market_area/saw/market_area_saw.tscn" id="6"]
-[ext_resource type="PackedScene" path="res://market_area/bed/market_area_bed.tscn" id="7"]
+[ext_resource type="PackedScene" uid="uid://cuuc0a2d8otyk" path="res://market_area/saw/market_area_saw.tscn" id="6"]
+[ext_resource type="PackedScene" uid="uid://c47mcaehpx57c" path="res://market_area/bed/market_area_bed.tscn" id="7"]
 [ext_resource type="AudioStream" uid="uid://d1o4lmj33cjoy" path="res://assets/cannot-afford.wav" id="8"]
-[ext_resource type="PackedScene" path="res://market_area/mailbox/market_area_mailbox.tscn" id="9"]
-[ext_resource type="PackedScene" path="res://market_area/valentine/market_area_valentine.tscn" id="10"]
-[ext_resource type="PackedScene" path="res://market_area/house/market_area_house.tscn" id="11"]
-[ext_resource type="PackedScene" path="res://market_area/pizza_box/market_area_pizza_box.tscn" id="12"]
+[ext_resource type="PackedScene" uid="uid://2keobhkumtck" path="res://market_area/mailbox/market_area_mailbox.tscn" id="9"]
+[ext_resource type="PackedScene" uid="uid://c7vxhl04stlgs" path="res://market_area/valentine/market_area_valentine.tscn" id="10"]
+[ext_resource type="PackedScene" uid="uid://bgw0dbelj5qsc" path="res://market_area/house/market_area_house.tscn" id="11"]
+[ext_resource type="PackedScene" uid="uid://dyl0c1wveiow" path="res://market_area/pizza_box/market_area_pizza_box.tscn" id="12"]
 
 [node name="Main" type="Node" unique_id=508665826]
 script = ExtResource("1")
@@ -38,7 +38,6 @@ position = Vector2(835, 240)
 position = Vector2(510, 305)
 
 [node name="HUD" parent="." unique_id=1499984137 instance=ExtResource("2")]
-anchors_preset = 15
 
 [node name="Tax_Timer" type="Timer" parent="." unique_id=1465391825]
 autostart = true

--- a/market_area/bed/market_area_bed.tscn
+++ b/market_area/bed/market_area_bed.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_lq3b8"]
 [ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="7"]
@@ -100,6 +101,11 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=361817441]
 z_index = -1
@@ -153,6 +159,7 @@ libraries/ = SubResource("AnimationLibrary_ib65x")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=2100192330]
 layout_mode = 2
+theme = ExtResource("4_lq3b8")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1048842051]
 layout_mode = 2
@@ -167,6 +174,7 @@ texture = ExtResource("3")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=86347704]
 layout_mode = 2
+theme = ExtResource("4_lq3b8")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=588797226]
 layout_mode = 2

--- a/market_area/bed/market_area_bed.tscn
+++ b/market_area/bed/market_area_bed.tscn
@@ -163,6 +163,7 @@ theme = ExtResource("4_lq3b8")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1048842051]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-"
@@ -178,6 +179,7 @@ theme = ExtResource("4_lq3b8")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=588797226]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+"

--- a/market_area/bed/market_area_bed.tscn
+++ b/market_area/bed/market_area_bed.tscn
@@ -1,180 +1,184 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene format=3 uid="uid://c47mcaehpx57c"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://assets/star-coin.png" type="Texture2D" id=3]
-[ext_resource path="res://assets/heart.png" type="Texture2D" id=5]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=6]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=7]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="6"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="7"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2"), ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_ib65x"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1"), ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=361817441]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1416600157]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=647536575]
+texture = ExtResource("6")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=108081660]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=1706139929]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 124.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1069877364]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "Bed"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 124.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=851619655]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 54.0
-offset_top = 42.0
-offset_right = 70.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=957218430]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 7 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("7")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1089033490]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1018153178]
+libraries/ = SubResource("AnimationLibrary_ib65x")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 124.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=2100192330]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 11.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1048842051]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-"
-valign = 1
+vertical_alignment = 1
 
-[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 15.0
-offset_right = 47.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=651447415]
+layout_mode = 2
+texture = ExtResource("3")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=86347704]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 18.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=588797226]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+"
-valign = 1
+vertical_alignment = 1
 
-[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 22.0
-offset_right = 54.0
-offset_bottom = 38.0
-texture = ExtResource( 5 )
+[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=2138925875]
+layout_mode = 2
+texture = ExtResource("5")
 
-[node name="Health 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 58.0
-offset_right = 90.0
-offset_bottom = 38.0
-texture = ExtResource( 5 )
+[node name="Health 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1017317316]
+layout_mode = 2
+texture = ExtResource("5")

--- a/market_area/house/market_area_house.tscn
+++ b/market_area/house/market_area_house.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://cwb3e2bcbiu1w" path="res://assets/pizza-slice.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="4"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_4spwd"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="6"]
 
@@ -100,6 +101,11 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=1657773658]
 z_index = -1
@@ -153,6 +159,7 @@ libraries/ = SubResource("AnimationLibrary_bni2o")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=820686101]
 layout_mode = 2
+theme = ExtResource("4_4spwd")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1536403703]
 layout_mode = 2
@@ -167,6 +174,7 @@ texture = ExtResource("4")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=691044206]
 layout_mode = 2
+theme = ExtResource("4_4spwd")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=2000706258]
 layout_mode = 2

--- a/market_area/house/market_area_house.tscn
+++ b/market_area/house/market_area_house.tscn
@@ -1,174 +1,180 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene format=3 uid="uid://bgw0dbelj5qsc"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://assets/pizza-slice.png" type="Texture2D" id=3]
-[ext_resource path="res://assets/envelope.png" type="Texture2D" id=4]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=5]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=6]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://cwb3e2bcbiu1w" path="res://assets/pizza-slice.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="6"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2"), ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bni2o"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1"), ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=1657773658]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=51268487]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=1832881924]
+texture = ExtResource("5")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=1387179153]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 126.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=899055505]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 126.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1293727668]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "House"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 126.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=189074680]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 55.0
-offset_top = 42.0
-offset_right = 71.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=704465356]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("6")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1019969644]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1557180518]
+libraries/ = SubResource("AnimationLibrary_bni2o")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 126.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=820686101]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 11.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1536403703]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-"
-valign = 1
+vertical_alignment = 1
 
-[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 15.0
-offset_right = 47.0
-offset_bottom = 38.0
-texture = ExtResource( 4 )
+[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=2137997142]
+layout_mode = 2
+texture = ExtResource("4")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 126.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=691044206]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 18.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=2000706258]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+"
-valign = 1
+vertical_alignment = 1
 
-[node name="Pizza Slice 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 22.0
-offset_right = 54.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Pizza Slice 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1030182257]
+layout_mode = 2
+texture = ExtResource("3")

--- a/market_area/house/market_area_house.tscn
+++ b/market_area/house/market_area_house.tscn
@@ -163,6 +163,7 @@ theme = ExtResource("4_4spwd")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1536403703]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-"
@@ -178,6 +179,7 @@ theme = ExtResource("4_4spwd")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=2000706258]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+"

--- a/market_area/mailbox/market_area_mailbox.tscn
+++ b/market_area/mailbox/market_area_mailbox.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="4"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_cj483"]
 [ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="7"]
@@ -13,6 +14,9 @@ size = Vector2(127.0654, 143.0786)
 
 [sub_resource type="FontFile" id="2"]
 fallbacks = Array[Font]([ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -81,6 +85,9 @@ _data = {
 
 [sub_resource type="FontFile" id="4"]
 fallbacks = Array[Font]([ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -95,6 +102,56 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/32/0/ascent = 0.0
+cache/0/32/0/descent = 0.0
+cache/0/32/0/underline_position = 0.0
+cache/0/32/0/underline_thickness = 0.0
+cache/0/32/0/scale = 1.0
+cache/0/31/0/ascent = 0.0
+cache/0/31/0/descent = 0.0
+cache/0/31/0/underline_position = 0.0
+cache/0/31/0/underline_thickness = 0.0
+cache/0/31/0/scale = 1.0
+cache/0/30/0/ascent = 0.0
+cache/0/30/0/descent = 0.0
+cache/0/30/0/underline_position = 0.0
+cache/0/30/0/underline_thickness = 0.0
+cache/0/30/0/scale = 1.0
+cache/0/29/0/ascent = 0.0
+cache/0/29/0/descent = 0.0
+cache/0/29/0/underline_position = 0.0
+cache/0/29/0/underline_thickness = 0.0
+cache/0/29/0/scale = 1.0
+cache/0/28/0/ascent = 0.0
+cache/0/28/0/descent = 0.0
+cache/0/28/0/underline_position = 0.0
+cache/0/28/0/underline_thickness = 0.0
+cache/0/28/0/scale = 1.0
+cache/0/27/0/ascent = 0.0
+cache/0/27/0/descent = 0.0
+cache/0/27/0/underline_position = 0.0
+cache/0/27/0/underline_thickness = 0.0
+cache/0/27/0/scale = 1.0
+cache/0/26/0/ascent = 0.0
+cache/0/26/0/descent = 0.0
+cache/0/26/0/underline_position = 0.0
+cache/0/26/0/underline_thickness = 0.0
+cache/0/26/0/scale = 1.0
+cache/0/25/0/ascent = 0.0
+cache/0/25/0/descent = 0.0
+cache/0/25/0/underline_position = 0.0
+cache/0/25/0/underline_thickness = 0.0
+cache/0/25/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
+cache/0/23/0/ascent = 0.0
+cache/0/23/0/descent = 0.0
+cache/0/23/0/underline_position = 0.0
+cache/0/23/0/underline_thickness = 0.0
+cache/0/23/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=628502714]
 z_index = -1
@@ -148,6 +205,7 @@ libraries/ = SubResource("AnimationLibrary_l5rtw")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1671794598]
 layout_mode = 2
+theme = ExtResource("4_cj483")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1790782746]
 layout_mode = 2
@@ -166,6 +224,7 @@ texture = ExtResource("6")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=462920735]
 layout_mode = 2
+theme = ExtResource("4_cj483")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=509485317]
 layout_mode = 2

--- a/market_area/mailbox/market_area_mailbox.tscn
+++ b/market_area/mailbox/market_area_mailbox.tscn
@@ -1,181 +1,179 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene format=3 uid="uid://2keobhkumtck"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=3]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=4]
-[ext_resource path="res://assets/heart.png" type="Texture2D" id=5]
-[ext_resource path="res://assets/star-coin.png" type="Texture2D" id=6]
-[ext_resource path="res://assets/envelope.png" type="Texture2D" id=7]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="6"]
+[ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="7"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_l5rtw"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=628502714]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=683610513]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=983447469]
+texture = ExtResource("3")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=1844621014]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=870914607]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 124.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1689585629]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "Mailbox"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 124.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1661307578]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 54.0
-offset_top = 42.0
-offset_right = 70.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=321175838]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("4")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=946865185]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=2093285573]
+libraries/ = SubResource("AnimationLibrary_l5rtw")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 124.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1671794598]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 11.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1790782746]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-"
-valign = 1
+vertical_alignment = 1
 
-[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 15.0
-offset_right = 47.0
-offset_bottom = 38.0
-texture = ExtResource( 5 )
+[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=532431397]
+layout_mode = 2
+texture = ExtResource("5")
 
-[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 51.0
-offset_right = 83.0
-offset_bottom = 38.0
-texture = ExtResource( 6 )
+[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1959856074]
+layout_mode = 2
+texture = ExtResource("6")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=462920735]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 36.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=509485317]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+5"
-valign = 1
+vertical_alignment = 1
 
-[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 40.0
-offset_right = 72.0
-offset_bottom = 38.0
-texture = ExtResource( 7 )
+[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1856665229]
+layout_mode = 2
+texture = ExtResource("7")

--- a/market_area/mailbox/market_area_mailbox.tscn
+++ b/market_area/mailbox/market_area_mailbox.tscn
@@ -209,6 +209,7 @@ theme = ExtResource("4_cj483")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1790782746]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-"
@@ -228,6 +229,7 @@ theme = ExtResource("4_cj483")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=509485317]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+5"

--- a/market_area/pizza_box/market_area_pizza_box.tscn
+++ b/market_area/pizza_box/market_area_pizza_box.tscn
@@ -106,6 +106,26 @@ cache/0/24/0/descent = 0.0
 cache/0/24/0/underline_position = 0.0
 cache/0/24/0/underline_thickness = 0.0
 cache/0/24/0/scale = 1.0
+cache/0/25/0/ascent = 0.0
+cache/0/25/0/descent = 0.0
+cache/0/25/0/underline_position = 0.0
+cache/0/25/0/underline_thickness = 0.0
+cache/0/25/0/scale = 1.0
+cache/0/26/0/ascent = 0.0
+cache/0/26/0/descent = 0.0
+cache/0/26/0/underline_position = 0.0
+cache/0/26/0/underline_thickness = 0.0
+cache/0/26/0/scale = 1.0
+cache/0/27/0/ascent = 0.0
+cache/0/27/0/descent = 0.0
+cache/0/27/0/underline_position = 0.0
+cache/0/27/0/underline_thickness = 0.0
+cache/0/27/0/scale = 1.0
+cache/0/28/0/ascent = 0.0
+cache/0/28/0/descent = 0.0
+cache/0/28/0/underline_position = 0.0
+cache/0/28/0/underline_thickness = 0.0
+cache/0/28/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=1850960190]
 z_index = -1
@@ -163,10 +183,10 @@ theme = ExtResource("4_deqxg")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1003339946]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-8"
-vertical_alignment = 1
 
 [node name="Pizza Slice 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1911798812]
 layout_mode = 2
@@ -178,6 +198,7 @@ theme = ExtResource("4_deqxg")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=560490516]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+20"

--- a/market_area/pizza_box/market_area_pizza_box.tscn
+++ b/market_area/pizza_box/market_area_pizza_box.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://cwb3e2bcbiu1w" path="res://assets/pizza-slice.png" id="4"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_deqxg"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="6"]
 
@@ -12,6 +13,9 @@ size = Vector2(127.0654, 143.0786)
 
 [sub_resource type="FontFile" id="2"]
 fallbacks = Array[Font]([ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -80,6 +84,9 @@ _data = {
 
 [sub_resource type="FontFile" id="4"]
 fallbacks = Array[Font]([ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -94,6 +101,11 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=1850960190]
 z_index = -1
@@ -147,6 +159,7 @@ libraries/ = SubResource("AnimationLibrary_uhusa")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=586630730]
 layout_mode = 2
+theme = ExtResource("4_deqxg")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1003339946]
 layout_mode = 2
@@ -161,6 +174,7 @@ texture = ExtResource("4")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1023955773]
 layout_mode = 2
+theme = ExtResource("4_deqxg")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=560490516]
 layout_mode = 2

--- a/market_area/pizza_box/market_area_pizza_box.tscn
+++ b/market_area/pizza_box/market_area_pizza_box.tscn
@@ -1,177 +1,174 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene format=3 uid="uid://dyl0c1wveiow"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://assets/star-coin.png" type="Texture2D" id=3]
-[ext_resource path="res://assets/pizza-slice.png" type="Texture2D" id=4]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=5]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=6]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://cwb3e2bcbiu1w" path="res://assets/pizza-slice.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="6"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_uhusa"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=1850960190]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=693963274]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=119751087]
+texture = ExtResource("5")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=1816000523]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=612095968]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 124.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1522839040]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "Pizza Box"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 124.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1483461326]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 54.0
-offset_top = 42.0
-offset_right = 70.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=334189882]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 6 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("6")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=674719082]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1326478828]
+libraries/ = SubResource("AnimationLibrary_uhusa")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 124.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=586630730]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 29.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1003339946]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-8"
-valign = 1
+vertical_alignment = 1
 
-[node name="Pizza Slice 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 33.0
-offset_right = 65.0
-offset_bottom = 38.0
-texture = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="Pizza Slice 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1911798812]
+layout_mode = 2
+texture = ExtResource("4")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1023955773]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 54.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=560490516]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+20"
-valign = 1
+vertical_alignment = 1
 
-[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 58.0
-offset_right = 90.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=843556120]
+layout_mode = 2
+texture = ExtResource("3")

--- a/market_area/saw/market_area_saw.tscn
+++ b/market_area/saw/market_area_saw.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="4"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_61646"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://dw6q5e5eo0dvi" path="res://assets/smile.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="7"]
@@ -13,6 +14,9 @@ size = Vector2(127.0654, 143.0786)
 
 [sub_resource type="FontFile" id="2"]
 fallbacks = Array[Font]([ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -81,6 +85,9 @@ _data = {
 
 [sub_resource type="FontFile" id="4"]
 fallbacks = Array[Font]([ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -95,6 +102,11 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=1923842272]
 z_index = -1
@@ -148,6 +160,7 @@ libraries/ = SubResource("AnimationLibrary_a5gmm")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=191839764]
 layout_mode = 2
+theme = ExtResource("4_61646")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1361769312]
 layout_mode = 2
@@ -166,6 +179,7 @@ texture = ExtResource("6")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1850893925]
 layout_mode = 2
+theme = ExtResource("4_61646")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1292671803]
 layout_mode = 2

--- a/market_area/saw/market_area_saw.tscn
+++ b/market_area/saw/market_area_saw.tscn
@@ -1,187 +1,183 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene format=3 uid="uid://cuuc0a2d8otyk"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://assets/star-coin.png" type="Texture2D" id=3]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=4]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=5]
-[ext_resource path="res://assets/smile.png" type="Texture2D" id=6]
-[ext_resource path="res://assets/heart.png" type="Texture2D" id=7]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://b1g370hhvnuic" path="res://assets/star-coin.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://dw6q5e5eo0dvi" path="res://assets/smile.png" id="6"]
+[ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="7"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_a5gmm"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=1923842272]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=964786995]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=1332964453]
+texture = ExtResource("4")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=1024599882]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=1674558043]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 124.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=507579480]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "Saw"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 124.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=2004855453]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 54.0
-offset_top = 42.0
-offset_right = 70.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=329760789]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("5")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=69394781]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=178785525]
+libraries/ = SubResource("AnimationLibrary_a5gmm")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 124.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=191839764]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 11.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1361769312]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-"
-valign = 1
+vertical_alignment = 1
 
-[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 15.0
-offset_right = 47.0
-offset_bottom = 38.0
-texture = ExtResource( 7 )
+[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1002266937]
+layout_mode = 2
+texture = ExtResource("7")
 
-[node name="Smile 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 51.0
-offset_right = 83.0
-offset_bottom = 38.0
-texture = ExtResource( 6 )
+[node name="Smile 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1172308110]
+layout_mode = 2
+texture = ExtResource("6")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 124.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1850893925]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 18.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1292671803]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+"
-valign = 1
+vertical_alignment = 1
 
-[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 22.0
-offset_right = 54.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Star Coin 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=335123009]
+layout_mode = 2
+texture = ExtResource("3")
 
-[node name="Star Coin 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 58.0
-offset_right = 90.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Star Coin 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=97473648]
+layout_mode = 2
+texture = ExtResource("3")

--- a/market_area/saw/market_area_saw.tscn
+++ b/market_area/saw/market_area_saw.tscn
@@ -164,6 +164,7 @@ theme = ExtResource("4_61646")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1361769312]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-"
@@ -183,6 +184,7 @@ theme = ExtResource("4_61646")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1292671803]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+"

--- a/market_area/valentine/market_area_valentine.tscn
+++ b/market_area/valentine/market_area_valentine.tscn
@@ -164,6 +164,7 @@ theme = ExtResource("4_sutsr")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=270889837]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "-"
@@ -179,6 +180,7 @@ theme = ExtResource("4_sutsr")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1474831128]
 layout_mode = 2
+size_flags_vertical = 8
 theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_fonts/font = SubResource("4")
 text = "+"

--- a/market_area/valentine/market_area_valentine.tscn
+++ b/market_area/valentine/market_area_valentine.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
 [ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="3"]
 [ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="4"]
+[ext_resource type="Theme" uid="uid://cn2i804sa0rst" path="res://assets/themes/font_size_market_area_numbers_theme.tres" id="4_sutsr"]
 [ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="5"]
 [ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="6"]
 [ext_resource type="Texture2D" uid="uid://dw6q5e5eo0dvi" path="res://assets/smile.png" id="7"]
@@ -13,6 +14,9 @@ size = Vector2(127.0654, 143.0786)
 
 [sub_resource type="FontFile" id="2"]
 fallbacks = Array[Font]([ExtResource("2")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -81,6 +85,9 @@ _data = {
 
 [sub_resource type="FontFile" id="4"]
 fallbacks = Array[Font]([ExtResource("1")])
+subpixel_positioning = 0
+msdf_pixel_range = 14
+msdf_size = 128
 cache/0/variation_coordinates = {}
 cache/0/face_index = 0
 cache/0/embolden = 0.0
@@ -95,6 +102,11 @@ cache/0/16/0/descent = 0.0
 cache/0/16/0/underline_position = 0.0
 cache/0/16/0/underline_thickness = 0.0
 cache/0/16/0/scale = 1.0
+cache/0/24/0/ascent = 0.0
+cache/0/24/0/descent = 0.0
+cache/0/24/0/underline_position = 0.0
+cache/0/24/0/underline_thickness = 0.0
+cache/0/24/0/scale = 1.0
 
 [node name="Node2D" type="Area2D" unique_id=1983885296]
 z_index = -1
@@ -148,6 +160,7 @@ libraries/ = SubResource("AnimationLibrary_83kxj")
 
 [node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=950659766]
 layout_mode = 2
+theme = ExtResource("4_sutsr")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=270889837]
 layout_mode = 2
@@ -162,6 +175,7 @@ texture = ExtResource("3")
 
 [node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1241132901]
 layout_mode = 2
+theme = ExtResource("4_sutsr")
 
 [node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1474831128]
 layout_mode = 2

--- a/market_area/valentine/market_area_valentine.tscn
+++ b/market_area/valentine/market_area_valentine.tscn
@@ -1,187 +1,183 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene format=3 uid="uid://c7vxhl04stlgs"]
 
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Medium.ttf" type="FontFile" id=1]
-[ext_resource path="res://assets/fonts/Roboto/Roboto-Regular.ttf" type="FontFile" id=2]
-[ext_resource path="res://assets/envelope.png" type="Texture2D" id=3]
-[ext_resource path="res://market_area/collision-box_128x140.png" type="Texture2D" id=4]
-[ext_resource path="res://assets/checkmark.png" type="Texture2D" id=5]
-[ext_resource path="res://assets/heart.png" type="Texture2D" id=6]
-[ext_resource path="res://assets/smile.png" type="Texture2D" id=7]
+[ext_resource type="FontFile" uid="uid://3ck2cfwdr0x" path="res://assets/fonts/Roboto/Roboto-Medium.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://2h3iuuytjtsa" path="res://assets/fonts/Roboto/Roboto-Regular.ttf" id="2"]
+[ext_resource type="Texture2D" uid="uid://dp000fgvx38bi" path="res://assets/envelope.png" id="3"]
+[ext_resource type="Texture2D" uid="uid://6vddlyfsfyu" path="res://market_area/collision-box_128x140.png" id="4"]
+[ext_resource type="Texture2D" uid="uid://cxfxo3uy8w6df" path="res://assets/checkmark.png" id="5"]
+[ext_resource type="Texture2D" uid="uid://c27donru45m4o" path="res://assets/heart.png" id="6"]
+[ext_resource type="Texture2D" uid="uid://dw6q5e5eo0dvi" path="res://assets/smile.png" id="7"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 63.5327, 71.5393 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(127.0654, 143.0786)
 
-[sub_resource type="FontFile" id=2]
-size = 14
-font_data = ExtResource( 2 )
+[sub_resource type="FontFile" id="2"]
+fallbacks = Array[Font]([ExtResource("2")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
 
-[sub_resource type="Animation" id=3]
+[sub_resource type="Animation" id="3"]
 tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
 tracks/0/path = NodePath("ColorRect:color:r")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
-tracks/0/imported = false
-tracks/0/enabled = true
 tracks/0/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
 tracks/1/path = NodePath("ColorRect:color:g")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
-tracks/1/imported = false
-tracks/1/enabled = true
 tracks/1/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
 tracks/2/path = NodePath("ColorRect:color:b")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
-tracks/2/imported = false
-tracks/2/enabled = true
 tracks/2/keys = {
-"points": PackedFloat32Array( 0.764706, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0 )
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0.764706, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
 }
 tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
 tracks/3/path = NodePath("ColorRect:color:a")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
-tracks/3/imported = false
-tracks/3/enabled = true
 tracks/3/keys = {
-"points": PackedFloat32Array( 1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0 ),
-"times": PackedFloat32Array( 0, 0.5, 0.6, 1 )
+"handle_modes": PackedInt32Array(0, 0, 0, 0),
+"points": PackedFloat32Array(1, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 0, -0.25, 0, 0.25, 0, 1, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0, 0.5, 0.6, 1)
 }
 
-[sub_resource type="FontFile" id=4]
-size = 32
-font_data = ExtResource( 1 )
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_83kxj"]
+_data = {
+&"Fade Checkmark Animation": SubResource("3")
+}
 
-[node name="Node2D" type="Area2D"]
+[sub_resource type="FontFile" id="4"]
+fallbacks = Array[Font]([ExtResource("1")])
+cache/0/variation_coordinates = {}
+cache/0/face_index = 0
+cache/0/embolden = 0.0
+cache/0/transform = Transform2D(1, 0, 0, 1, 0, 0)
+cache/0/spacing_top = 0
+cache/0/spacing_bottom = 0
+cache/0/spacing_space = 0
+cache/0/spacing_glyph = 0
+cache/0/baseline_offset = 0.0
+cache/0/16/0/ascent = 0.0
+cache/0/16/0/descent = 0.0
+cache/0/16/0/underline_position = 0.0
+cache/0/16/0/underline_thickness = 0.0
+cache/0/16/0/scale = 1.0
+
+[node name="Node2D" type="Area2D" unique_id=1983885296]
 z_index = -1
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( 65.054, 69.5895 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=437182679]
+position = Vector2(65.054, 69.5895)
+shape = SubResource("1")
 
-[node name="TextureRect" type="TextureRect" parent="."]
-texture = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+[node name="TextureRect" type="TextureRect" parent="." unique_id=1901848672]
+texture = ExtResource("4")
 
-[node name="MarginContainer" type="MarginContainer" parent="TextureRect"]
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect" unique_id=1566368606]
+layout_mode = 0
 offset_left = 2.0
 offset_top = 1.0
 offset_right = 126.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer"]
-offset_right = 126.0
-offset_bottom = 142.0
+[node name="Vertical Sections" type="VBoxContainer" parent="TextureRect/MarginContainer" unique_id=1978268537]
+layout_mode = 2
 size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
-[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_right = 126.0
-offset_bottom = 17.0
+[node name="Header Title" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=15619796]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 text = "Valentine"
-align = 1
-autowrap = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
+horizontal_alignment = 1
 
-[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 21.0
-offset_right = 126.0
-offset_bottom = 38.0
+[node name="Explanation" type="Label" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1597592224]
+layout_mode = 2
 size_flags_vertical = 3
-theme_override_fonts/font = SubResource( 2 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
-autowrap = true
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("2")
 
-[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_left = 55.0
-offset_top = 42.0
-offset_right = 71.0
-offset_bottom = 58.0
+[node name="Active Checkmark" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=946773542]
+layout_mode = 2
 size_flags_horizontal = 4
-texture = ExtResource( 5 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("5")
 
-[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
+[node name="ColorRect" type="ColorRect" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1272288670]
+layout_mode = 0
 offset_right = 16.0
 offset_bottom = 16.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-color = Color( 0.764706, 0.764706, 0.764706, 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
+color = Color(0.764706, 0.764706, 0.764706, 1)
 
-[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark"]
-"anims/Fade Checkmark Animation" = SubResource( 3 )
+[node name="Fade In Out" type="AnimationPlayer" parent="TextureRect/MarginContainer/Vertical Sections/Active Checkmark" unique_id=1368040818]
+libraries/ = SubResource("AnimationLibrary_83kxj")
 
-[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 62.0
-offset_right = 126.0
-offset_bottom = 100.0
+[node name="Cost Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=950659766]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_right = 11.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=270889837]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "-"
-valign = 1
+vertical_alignment = 1
 
-[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons"]
-offset_left = 15.0
-offset_right = 47.0
-offset_bottom = 38.0
-texture = ExtResource( 3 )
+[node name="Envelope 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Cost Icons" unique_id=1040543133]
+layout_mode = 2
+texture = ExtResource("3")
 
-[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections"]
-offset_top = 104.0
-offset_right = 126.0
-offset_bottom = 142.0
+[node name="Benefit Icons" type="HBoxContainer" parent="TextureRect/MarginContainer/Vertical Sections" unique_id=1241132901]
+layout_mode = 2
 
-[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_right = 18.0
-offset_bottom = 38.0
-theme_override_fonts/font = SubResource( 4 )
-theme_override_colors/font_color = Color( 0, 0, 0, 1 )
+[node name="Label" type="Label" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1474831128]
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = SubResource("4")
 text = "+"
-valign = 1
+vertical_alignment = 1
 
-[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 22.0
-offset_right = 54.0
-offset_bottom = 38.0
-texture = ExtResource( 6 )
+[node name="Health 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=213254206]
+layout_mode = 2
+texture = ExtResource("6")
 
-[node name="Smile 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 58.0
-offset_right = 90.0
-offset_bottom = 38.0
-texture = ExtResource( 7 )
+[node name="Smile 1" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=515340470]
+layout_mode = 2
+texture = ExtResource("7")
 
-[node name="Smile 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons"]
-offset_left = 94.0
-offset_right = 126.0
-offset_bottom = 38.0
-texture = ExtResource( 7 )
+[node name="Smile 2" type="TextureRect" parent="TextureRect/MarginContainer/Vertical Sections/Benefit Icons" unique_id=1698147527]
+layout_mode = 2
+texture = ExtResource("7")

--- a/player/player.tscn
+++ b/player/player.tscn
@@ -1,16 +1,16 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene format=3 uid="uid://dbagp57b81o6t"]
 
-[ext_resource path="res://player/player.png" type="Texture2D" id=1]
-[ext_resource path="res://player/player.gd" type="Script" id=2]
+[ext_resource type="Texture2D" uid="uid://bpbha5qnio33d" path="res://player/player.png" id="1"]
+[ext_resource type="Script" uid="uid://dt7l8cdr5q1cn" path="res://player/player.gd" id="2"]
 
-[sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 32, 32 )
+[sub_resource type="RectangleShape2D" id="1"]
+size = Vector2(64, 64)
 
-[node name="Player" type="CharacterBody2D"]
-script = ExtResource( 2 )
+[node name="Player" type="CharacterBody2D" unique_id=1094103532]
+script = ExtResource("2")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource( 1 )
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=437640310]
+texture = ExtResource("1")
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 1 )
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1039617299]
+shape = SubResource("1")

--- a/project.godot
+++ b/project.godot
@@ -8,11 +8,15 @@
 
 config_version=5
 
+[animation]
+
+compatibility/default_parent_skeleton_in_mesh_instance_3d=true
+
 [application]
 
 config/name="ludum-dare-47-enough"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.5")
+config/features=PackedStringArray("4.6")
 config/icon="res://icon.png"
 
 [autoload]


### PR DESCRIPTION
Upgrade from Godot 4.5 to 4.6 so it is easier to locally run and make enhancements to the game.

## Implementation Details

First, launch the game and save each scene to automatically touch files.

Second, make cost and benefit signs and numbers of the market areas slightly larger at 24px. They were smaller as of at least Godot 4.4.1, merged PR https://github.com/NBumgardner/ludum-dare-47-enough/pull/41.

Lastly, bump the documented Godot version in the README.md file.

### Out of Scope

30px font would be closer to the original size, yet would also require changing icons to not stretch. At that point, it would probably be better to encapsulate the visual of a market area and have all of the styles fixed in one place.

### Screenshot

<img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/54633a60-04ab-4c32-9836-8397e6f06f24" />

_**Screenshot 1:** Screenshot of running the game locally for the pending PR._