### PR TITLE
Engine Update - Equivalently Upgrade to Latest Godot 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Team members include:
 Coded using the [Godot](https://godotengine.org) game engine.
 
 The original game jam version, tagged as `ld47-submission` and [hosted on itch.io](https://nbumgardner.itch.io/ludum-dare-47-enough), runs on Godot version 3.2.
-The latest stable `master` code branch runs on Godot version 4.6.
+The latest stable `master` code branch runs on Godot version 4.7.
 
 ### License
 This game's code is open-source under the MIT License.

--- a/project.godot
+++ b/project.godot
@@ -16,7 +16,7 @@ compatibility/default_parent_skeleton_in_mesh_instance_3d=true
 
 config/name="ludum-dare-47-enough"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 config/icon="res://icon.png"
 
 [autoload]


### PR DESCRIPTION
Upgrade from Godot 4.6 to 4.7 so it is easier to locally run and make enhancements to the game.